### PR TITLE
Change paper PDF url to USENIX official link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 FishFuzz is an input prioritization strategy that efficiently direct fuzzing towards the promising sanitizer targets. We implement the FishFuzz prototype based on [AFL](https://github.com/google/afl) and [AFL++](https://github.com/AFLplusplus/AFLplusplus/).
 
-For more details, check out our [paper](https://hexhive.epfl.ch/paper/23SEC5.pdf). To cite our work, you can use the following BibTeX entry:
+For more details, check out our [paper](https://www.usenix.org/system/files/usenixsecurity23-zheng.pdf). To cite our work, you can use the following BibTeX entry:
 
 ```bibtex
 @inproceedings{zheng2023fishfuzz,


### PR DESCRIPTION
The existing paper's URL is no longer valid and it has been updated to the official PDF link from Usenix :)

Please check: [HexHive one](https://hexhive.epfl.ch/paper/23SEC5.pdf)